### PR TITLE
feat: Gateway 서비스 인증 filter 구현

### DIFF
--- a/src/gateway-service/build.gradle
+++ b/src/gateway-service/build.gradle
@@ -41,6 +41,16 @@ dependencies {
 
 	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.108.Final:osx-aarch_64'
 
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// Spring Cloud OpenFeign
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	implementation("io.github.openfeign:feign-reactive-wrappers")
+	implementation 'io.github.openfeign:feign-gson'
+
 
 }
 

--- a/src/gateway-service/src/main/java/com/phishing/gatewayservice/config/OpenFeignConfig.java
+++ b/src/gateway-service/src/main/java/com/phishing/gatewayservice/config/OpenFeignConfig.java
@@ -1,0 +1,42 @@
+//package com.phishing.gatewayservice.config;
+//
+//import com.phishing.gatewayservice.external.PassportClient;
+//import feign.Logger;
+//import feign.form.spring.SpringFormEncoder;
+//import feign.gson.GsonDecoder;
+//import feign.gson.GsonEncoder;
+//import feign.reactive.ReactorDecoder;
+//import feign.reactive.ReactorFeign;
+//import org.springframework.beans.factory.ObjectFactory;
+//import org.springframework.boot.autoconfigure.http.HttpMessageConverters;
+//import org.springframework.cloud.openfeign.support.SpringDecoder;
+//import org.springframework.cloud.openfeign.support.SpringEncoder;
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//
+//// open feign config
+//@Configuration
+//public class OpenFeignConfig {
+//
+//    private final ObjectFactory<HttpMessageConverters> messageConverters = HttpMessageConverters::new;
+//
+//    @Bean
+//    public PassportClient passportClient() {
+//        return ReactorFeign.builder()
+//                .logLevel(Logger.Level.FULL)
+//                .encoder(new GsonEncoder())
+//                .decoder(new ReactorDecoder(new GsonDecoder()))
+//                .target(PassportClient.class, "http://localhost:8082");
+//    }
+//
+//    @Bean
+//    public SpringFormEncoder feignFormEncoder() {
+//        return new SpringFormEncoder(new SpringEncoder(messageConverters));
+//    }
+//
+//    @Bean
+//    public SpringDecoder feignFormDecoder() {
+//        return new SpringDecoder(messageConverters);
+//    }
+//
+//}

--- a/src/gateway-service/src/main/java/com/phishing/gatewayservice/external/PassportClient.java
+++ b/src/gateway-service/src/main/java/com/phishing/gatewayservice/external/PassportClient.java
@@ -1,0 +1,39 @@
+package com.phishing.gatewayservice.external;
+
+import feign.Headers;
+import feign.Param;
+import feign.RequestLine;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import reactor.core.publisher.Mono;
+
+//// open feign client
+//@Component
+//public interface PassportClient {
+//    @RequestLine("POST /auth/api/v1/passport")
+//    @Headers("Authorization: {token}")
+//    public Mono<ResponseEntity<String>> generatePassport(@Param("token") String token);
+//}
+
+@Component
+@Qualifier("passportClient")
+public class PassportClient {
+    private static final String AUTHORIZATION_HEADER_NAME = "Authorization";
+    private final RestClient restClient = RestClient.create();
+
+    @Value("${restclient.baseuri}")
+    private String baseUri;
+
+    public String generatePassport(String token) {
+        return restClient
+                .post()
+                .uri(baseUri + "/auth/api/v1/passport")
+                .header(AUTHORIZATION_HEADER_NAME, token)
+                .retrieve()
+                .toEntity(String.class)
+                .getBody();
+    }
+}

--- a/src/gateway-service/src/main/java/com/phishing/gatewayservice/filter/AuthenticationFilter.java
+++ b/src/gateway-service/src/main/java/com/phishing/gatewayservice/filter/AuthenticationFilter.java
@@ -1,0 +1,71 @@
+package com.phishing.gatewayservice.filter;
+
+import com.phishing.gatewayservice.external.PassportClient;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class AuthenticationFilter extends AbstractGatewayFilterFactory<AuthenticationFilter.Config> {
+
+    private final PassportClient passportClient;
+
+    public AuthenticationFilter(@Qualifier("passportClient") PassportClient passportClient) {
+        super(Config.class);
+        this.passportClient = passportClient;
+    }
+
+    public static class Config{}
+
+    @Override
+    public GatewayFilter apply (Config config){
+        return (exchange, chain) -> {
+            String uri = exchange.getRequest().getURI().getPath();
+
+            if (isWhiteListed(uri)){
+                return chain.filter(exchange);
+            }
+
+            if (!exchange.getRequest().getHeaders().containsKey("Authorization")){
+                exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+                return exchange.getResponse().setComplete();
+            }
+
+            String token = exchange.getRequest().getHeaders().get("Authorization").get(0);
+
+            // RestClient 사용
+            String passport = passportClient.generatePassport(token);
+
+            ServerHttpRequest request = exchange.getRequest().mutate()
+                                .header("X-Authorization", passport)
+                                .build();
+            return chain.filter(exchange.mutate().request(request).build());
+
+//            // open feign 사용
+//            return passportClient.generatePassport(token)
+//                    .flatMap(response -> {
+//                        String passport = response.getBody();
+//                        log.debug("Passport: {}", passport);
+//                        ServerHttpRequest request = exchange.getRequest().mutate()
+//                                .header("X-Authorization", passport)
+//                                .build();
+//                        return chain.filter(exchange.mutate().request(request).build());
+//                    });
+        };
+    }
+
+    private boolean isWhiteListed(String uri){
+        for (WhiteListUri whiteListedUri : WhiteListUri.values()){
+            if (whiteListedUri.uri.equals(uri)){
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/src/gateway-service/src/main/java/com/phishing/gatewayservice/filter/WhiteListUri.java
+++ b/src/gateway-service/src/main/java/com/phishing/gatewayservice/filter/WhiteListUri.java
@@ -1,0 +1,16 @@
+package com.phishing.gatewayservice.filter;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum WhiteListUri {
+    SIGNUP_URI("/auth/api/v1/signup"),
+    SIGNIN_URI("/auth/api/v1/signin"),
+    TOKEN_REFRESH_URI("/auth/api/v1/refresh"),
+    CHECK_EMAIL_URI("/auth/api/v1/users/check"),
+    SEND_MAIL_URI("/auth/api/v1/email/send"),
+    VERIFY_MAIL_URI("/auth/api/v1/email/verify"),
+
+    ;
+    final String uri;
+}

--- a/src/gateway-service/src/main/java/com/phishing/gatewayservice/payload/Passport.java
+++ b/src/gateway-service/src/main/java/com/phishing/gatewayservice/payload/Passport.java
@@ -1,0 +1,8 @@
+package com.phishing.gatewayservice.payload;
+
+public record Passport(
+    String email,
+    String nickname,
+    String role
+) {
+}

--- a/src/gateway-service/src/main/resources/application.yml
+++ b/src/gateway-service/src/main/resources/application.yml
@@ -11,6 +11,8 @@ eureka:
 spring:
   application:
     name: gateway-service
+  profiles:
+    active: jwt
   cloud:
     gateway:
         routes:
@@ -18,3 +20,12 @@ spring:
               uri: lb://AUTH-SERVICE
               predicates:
                 - Path=/auth/**
+              filters:
+                - AuthenticationFilter
+
+restclient:
+  baseuri: http://localhost:8082
+
+logging:
+  level:
+    feign: DEBUG

--- a/src/gateway-service/src/main/resources/application.yml
+++ b/src/gateway-service/src/main/resources/application.yml
@@ -11,8 +11,6 @@ eureka:
 spring:
   application:
     name: gateway-service
-  profiles:
-    active: jwt
   cloud:
     gateway:
         routes:


### PR DESCRIPTION
### Issue Number or Link
#4 

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
Gateway 서비스 인증 filter 구현

### 상세 내용(Describe your changes)
**Gateway 서비스 인증 필터 구현**
gateway를 통해 jwt 토큰에 대한 유효성을 검사하고 해당 유저에 대한 Passport를 발급합니다.
passport는 다음과 같이 이루어져 있습니다.
```
{
    "email" : "{email}"
    "nickname" : "{nickname}"
    "role" : "{role}"
}
````
Passport를 발급하기 위하여 gateway는 auth service와 통신을 하고,
이를 수행하기 위해 Spring의 RestClient를 사용합니다.

해당 필터를 거치지 않는 WhiteListUri들이 존재합니다.
- SIGNUP_URI
- SIGNIN_URI
- TOKEN_REFRESH_URI
- CHECK_EMAIL_URI
- SEND_MAIL_URI
- VERIFY_MAIL_URI


### 참고 사항
추후 RestClient를 대신하여 OpenFeign으로 변경할 수 있습니다.

